### PR TITLE
gitpod: fix Node version to 13.3.0

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,5 +3,4 @@ ports:
     onOpen: open-preview
 tasks:
   - before: if [[ -z "$experiment" ]]; then cd playground/1st-proof-of-concept; else cd playground/$experiment; fi
-    init: npm install
-    command: npm start
+    command: nvm install 13.3.0 && npm install && npm start


### PR DESCRIPTION
Não é a melhor forma de fazer isso... a melhor forma é buildando um container já com a versão do Node, mas infelizmente isso é incrivelmente mais demorado do que forçar uma instalação com o NVM (o que não sai de graça, porque tem um efeito colateral também). Mas como primeiro passo está ótimo.